### PR TITLE
Fix typo in experiment.json.

### DIFF
--- a/tutorials/a-simple-walkthrough/experiment.json
+++ b/tutorials/a-simple-walkthrough/experiment.json
@@ -89,7 +89,7 @@
     "rollbacks": [
         {
             "type": "action",
-            "name": "swap-to-vald-cert",
+            "name": "swap-to-valid-cert",
             "provider": {
                 "type": "process",
                 "path": "cp",


### PR DESCRIPTION
Fixed typo in rollback action name: `swap-to-vald-cert` → `swap-to-valid-cert`.