### PR TITLE
update version to latest compatiable

### DIFF
--- a/tutorials/a-simple-walkthrough/requirements.txt
+++ b/tutorials/a-simple-walkthrough/requirements.txt
@@ -1,4 +1,4 @@
-astral
+astral==1.10.1
 cherrypy
 pytz
 requests


### PR DESCRIPTION
The change is to fix following errors:
> $ python astre.py
> Traceback (most recent call last):
>   File "astre.py", line 4, in <module>
>     from astral import Astral
> ImportError: cannot import name 'Astral' from 'astral' (/Users/.../gitws/chaostoolkit-documentation-code/tutorials/a-simple-walkthrough/venv/lib/python3.7/site-packages/astral/__init__.py)