### PR TITLE
Daemonize astre and sunset

### DIFF
--- a/tutorials/a-simple-walkthrough/astre.py
+++ b/tutorials/a-simple-walkthrough/astre.py
@@ -49,6 +49,7 @@ def run():
         "server.ssl_certificate": os.path.join(cur_dir, "cert.pem")
     })
     PIDFile(cherrypy.engine, 'astre.pid').subscribe()
+    Daemonizer(cherrypy.engine).subscribe()
     cherrypy.quickstart(Root())
 
 

--- a/tutorials/a-simple-walkthrough/sunset.py
+++ b/tutorials/a-simple-walkthrough/sunset.py
@@ -36,6 +36,7 @@ def run():
         "server.ssl_certificate": cert_path
     })
     PIDFile(cherrypy.engine, 'sunset.pid').subscribe()
+    Daemonizer(cherrypy.engine).subscribe()
     cherrypy.quickstart(Root())
 
 


### PR DESCRIPTION
Correctly daemonize astre and sunset

For the [tutorial experiment](https://docs.chaostoolkit.org/reference/tutorial/#run-the-experiment_1), it involves spinning up two processes `astre` and `sunset`. Two of the tutorial experiment's `actions` are to restart the `astre` and `sunset` processes by sending `SIGHUP`.

However, because `astre` and `sunset` aren't daemonized by `cherrypy` (they only run as normal processes not daemons), the `SIGHUP` signal causes both of them to be killed rather than restarted. Only daemons restart upon receiving a `SIGHUP`. This issue is referenced in #3.

